### PR TITLE
Refer to the Flatcar docs version by the major version

### DIFF
--- a/docs/flatcar-container-linux/_index.md
+++ b/docs/flatcar-container-linux/_index.md
@@ -4,17 +4,12 @@ title: Flatcar Container Linux
 children_are_versions: true
 external_docs:
   - repo: https://github.com/kinvolk/flatcar-docs.git
-    name: "2605.7.0"
+    name: "2605"
     branch: "main"
     dir: "docs"
 sidebar:
   skip: true
   link: latest
-cascade:
-  alpha_channel: 2671.0.0
-  stable_channel: 2605.7.0
-  beta_channel: 2643.1.0
-  edge_channel: 2466.99.0
 weight: 10
 cascade:
   github_edit_url: https://github.com/kinvolk/flatcar-docs/edit/main/docs/


### PR DESCRIPTION
Releases that have the same major version are built from the same
maintenance branch where no big changes are made. Documentation
improvements don't have to be done for a particular release and it
could quickly be too much to handle. Just use the major version to
refer to the docs branch that was created when a new major version
was branched (but for now it's still "main" until we fix some basic
issues).
