### PR TITLE
Add search params to all projects

### DIFF
--- a/docs/flatcar-container-linux/_index.md.in
+++ b/docs/flatcar-container-linux/_index.md.in
@@ -13,5 +13,8 @@ weight: 10
 cascade:
   github_edit_url: https://github.com/kinvolk/flatcar-docs/edit/main/docs/
   issues_url: https://github.com/kinvolk/flatcar/issues/new?labels=kind/docs
+  search:
+    domain: flatcar
+    inputPlaceholder: Search Flatcar docs…
 @@FCL_VERSION_DATA@@
 ---

--- a/docs/headlamp/_index.md
+++ b/docs/headlamp/_index.md
@@ -13,5 +13,8 @@ sidebar:
 cascade:
   github_edit_url: https://github.com/kinvolk/headlamp/edit/master/docs
   issues_url: https://github.com/kinvolk/headlamp/issues/new
+  search:
+    domain: headlamp
+    inputPlaceholder: Search Headlamp docs…
 weight: 40
 ---

--- a/docs/inspektor-gadget/_index.md
+++ b/docs/inspektor-gadget/_index.md
@@ -13,5 +13,8 @@ sidebar:
 cascade:
   github_edit_url: https://github.com/kinvolk/inspektor-gadget/edit/master/docs
   issues_url: https://github.com/kinvolk/inspektor-gadget/issues/new
+  search:
+    domain: inspektor-gadget
+    inputPlaceholder: Search Inspektor Gadget docs…
 weight: 40
 ---

--- a/docs/lokomotive/_index.md
+++ b/docs/lokomotive/_index.md
@@ -13,5 +13,8 @@ sidebar:
 cascade:
   github_edit_url: https://github.com/kinvolk/lokomotive/edit/master/docs/
   issues_url: https://github.com/kinvolk/lokomotive/issues/new?labels=kind/documentation
+  search:
+    domain: lokomotive
+    inputPlaceholder: Search Lokomotive docs…
 weight: 30
 ---

--- a/docs/nebraska/_index.md
+++ b/docs/nebraska/_index.md
@@ -13,5 +13,8 @@ sidebar:
 cascade:
   github_edit_url: https://github.com/kinvolk/nebraska/edit/master/docs/
   issues_url: https://github.com/kinvolk/nebraska/issues/new
+  search:
+    domain: nebraska
+    inputPlaceholder: Search Nebraska docs…
 weight: 40
 ---


### PR DESCRIPTION
We now support search in the docs' renderer, but for that to be shown
and take the docs context into account we need to add this extra
information.