### PR TITLE
lokomotive: Add entry for 0.6

### DIFF
--- a/docs/lokomotive/_index.md
+++ b/docs/lokomotive/_index.md
@@ -3,10 +3,14 @@ content_type: lokomotive
 title: Lokomotive
 children_are_versions: true
 external_docs:
-  - repo: https://github.com/kinvolk/lokomotive.git
-    name: "0.5"
-    branch: "master"
-    dir: "docs"
+- repo: https://github.com/kinvolk/lokomotive.git
+  name: "0.6"
+  branch: "master"
+  dir: "docs"
+- repo: https://github.com/kinvolk/lokomotive.git
+  name: "0.5"
+  branch: "v0.5.0"
+  dir: "docs"
 sidebar:
   skip: true
   link: latest


### PR DESCRIPTION
### Changes

- This commit adds an entry for `0.6`.
- Point the `0.5` to `v0.5.0`.
- Fix the indentation of YAML.

### Testing done

None, I am not sure how test locally.

**NOTE:** Will be merged after the release is done for lokomotive https://github.com/kinvolk/lokomotive/pull/1292