### PR TITLE
Add support for a build_docs_cmd

### DIFF
--- a/docs/headlamp/_index.md
+++ b/docs/headlamp/_index.md
@@ -5,8 +5,9 @@ children_are_versions: true
 external_docs:
   - repo: https://github.com/kinvolk/headlamp.git
     name: "0.2"
-    branch: "master"
+    branch: "typedoc"
     dir: "docs"
+    build_cmd: "make docs"
 sidebar:
   skip: true
   link: latest

--- a/tools/docs-fetcher.py
+++ b/tools/docs-fetcher.py
@@ -69,6 +69,16 @@ def fetch_docs(file_path):
         docs['repo_name'] = repo_name
         docs['file'] = file_path
 
+        build_cmd = docs.get('build_cmd')
+        if build_cmd:
+            repo_path = os.path.join(
+                TOP_DIR_PATH,
+                EXTERNAL_REPOS_DIR,
+                repo_name
+            )
+            print("Running build command: ", build_cmd, ": in: ", repo_path)
+            subprocess.run(build_cmd, shell=True, cwd=repo_path)
+
         link_external_docs(os.path.join(repo_name, docs['dir']), os.path.join(dir_name, docs['name']))
 
 def link_external_docs(linked_dir, link_name):


### PR DESCRIPTION
If there is a build_docs_cmd it will be run on that repo.

```yaml
    buildDocsCmd: "make docs"
```

With headlamp I'd like to generate some documentation with the storybook and typedoc tools. There's an open PR for that here: https://github.com/kinvolk/headlamp/pull/204 (when that is merged, I will update the branch on this PR to go back to the main branch).
