### PR TITLE
lokomotive: remove extra `external_docs` section

### DIFF
--- a/docs/lokomotive/_index.md
+++ b/docs/lokomotive/_index.md
@@ -7,7 +7,6 @@ external_docs:
     name: "0.9"
     branch: "v0.9.0"
     dir: "docs"
-external_docs:
   - repo: https://github.com/kinvolk/lokomotive.git
     name: "0.8"
     branch: "v0.8.0"


### PR DESCRIPTION
It was added by mistake when adding the v0.9.0 tag.