### PR TITLE
docs/inspektor-gadget: update to version 0.4.2

### DIFF
--- a/docs/inspektor-gadget/_index.md
+++ b/docs/inspektor-gadget/_index.md
@@ -4,14 +4,14 @@ title: Inspektor Gadget
 children_are_versions: true
 external_docs:
   - repo: https://github.com/kinvolk/inspektor-gadget.git
-    name: "0.2"
+    name: "0.4.2"
     branch: "main"
     dir: "docs"
 sidebar:
   skip: true
   link: latest
 cascade:
-  github_edit_url: https://github.com/kinvolk/inspektor-gadget/edit/master/docs
+  github_edit_url: https://github.com/kinvolk/inspektor-gadget/edit/main/docs
   issues_url: https://github.com/kinvolk/inspektor-gadget/issues/new
   search:
     domain: inspektor-gadget


### PR DESCRIPTION
Docs entry for latest Inspektor Gadget v0.4.2

Do we need to keep previous versions?

cc @marga-kinvolk 